### PR TITLE
WIP: Changes necessary to use external parsers

### DIFF
--- a/_modules/module_utils.py
+++ b/_modules/module_utils.py
@@ -133,7 +133,9 @@ class ModuleBase(object):
         self._set_debug_mode(self.defaults)
 
         # Salt module parser
-        self.argparser = ArgumentParser(prog=__virtualname)
+        self.argparser = ArgumentParser(
+                prog=__virtualname,
+                parents=kwargs.pop('argparser_parents',[]))
         self.argparser.add_argument_group('salt')
         self.parser = self.argparser.get_argument_group('salt')
 

--- a/_modules/module_utils.py
+++ b/_modules/module_utils.py
@@ -133,9 +133,16 @@ class ModuleBase(object):
         self._set_debug_mode(self.defaults)
 
         # Salt module parser
-        self.argparser = ArgumentParser(
-                prog=__virtualname,
+        # FIXME: If the parent argparse already has --help, then adding it
+        # again would lead to an error. But now we might end up with no
+        # --help at all...
+        if 'argparser_parents' in kwargs:
+            self.argparser = ArgumentParser(
+                prog=__virtualname, add_help=False,
                 parents=kwargs.pop('argparser_parents',[]))
+        else:
+            self.argparser = ArgumentParser(prog=__virtualname)
+
         self.argparser.add_argument_group('salt')
         self.parser = self.argparser.get_argument_group('salt')
 


### PR DESCRIPTION
This is part of a project to deduplicate some similar code for parsing that occurs in both qubes-mgmt-salt-dom0-qvm and qubes-core-admin-client. For this we want to use an external parser for defining all the arguments, but still need the functions offered by `ArgumentParser` in `module_utils`.

With this pull request it becomes possible to do this by passing the external parser to `ModuleBase.__init__` via the new argument `argparser_parents`.