### PR TITLE
Adjust to fixed NAME field in os-release file

### DIFF
--- a/_grains/redefined_dom0_grains.py
+++ b/_grains/redefined_dom0_grains.py
@@ -16,6 +16,6 @@ def qubes_dom0():
     Redefine qubes grains.
     '''
     grains = {}
-    if salt.grains.core.os_data()['os'] == 'Qubes':
+    if salt.grains.core.os_data()['os'] in ('Qubes', 'Qubes OS'):
         grains = {'virtual': 'Qubes', 'os': 'Fedora', 'os_family': 'RedHat'}
     return grains


### PR DESCRIPTION
https://github.com/QubesOS/qubes-qubes-release/commit/3cd12224c3d63df82c2a1895df5eaede91b3e679
fixed quoting, so the NAME now has "Qubes OS" instead of just "Qubes".
Handle both cases in the dynamic grains module.

Fixes QubesOS/qubes-issues#9143