### PR TITLE
Use new devices API to list PCI devices

### DIFF
--- a/_grains/pci_devs.py
+++ b/_grains/pci_devs.py
@@ -2,53 +2,20 @@
 #
 # vim: set ts=4 sw=4 sts=4 et :
 
-from __future__ import print_function
-import subprocess
-import re
-
-# Import salt libs
-import salt.config
-import salt.grains.core
-import salt.utils
-
-
-# Handle legacy salt 2017.7.1
-try:
-    from salt.utils.path import which as _which
-except ImportError:
-    from salt.utils import which as _which
-
-__opts__ = salt.config.minion_config('/etc/salt/minion')
-salt.grains.core.__opts__ = __opts__
+import qubesadmin
 
 
 def pci_devs():
-    '''
+    """
     Useful PCI devices lists.
-    '''
+    """
+
+    app = qubesadmin.Qubes()
 
     def find_devices_of_class(klass):
-        lspci = _which('lspci')
-
-        if lspci:
-            p = subprocess.Popen([lspci, "-mm", "-n"], stdout=subprocess.PIPE)
-            result = p.communicate()
-            retcode = p.returncode
-
-            if retcode != 0:
-                print("ERROR when executing lspci!")
-                raise IOError
-
-            rx_netdev = re.compile(
-                r"^([0-9a-f]{2}:[0-9a-f]{2}.[0-9a-f]) \"" + klass
-            )
-
-            for dev in str(result[0].decode()).splitlines():
-                match = rx_netdev.match(dev)
-                if match is not None:
-                    dev_bdf = match.group(1)
-                    assert dev_bdf is not None
-                    yield dev_bdf
+        for dev in app.domains["dom0"].devices["pci"]:
+            if repr(dev.interfaces[0]).startswith("p" + klass):
+                yield dev.port_id
 
     grains = {
         'pci_net_devs': list(find_devices_of_class("02")),


### PR DESCRIPTION
Ask qubesd instead of parsing lspci output. This is necessary for
path-based PCI identifiers, but coincidentally it's also way simpler.

QubesOS/qubes-issues#8681