### PR TITLE
Fix reporting error status for multi-command actions

### DIFF
--- a/_utils/qubes_utils.py
+++ b/_utils/qubes_utils.py
@@ -223,14 +223,16 @@ class Status(argparse.Namespace):
             if status.comment.strip():
                 comment += linefeed(comment) + status.comment
 
-            # 'retcode' - Determine retcode
-            # Use 'result' over 'retcode' if result is not None as 'retcode'
-            # reflects last run state, where 'result' is set explicitly
-            if status.result is not None:
-                retcode = not status.result
+            # 'retcode' - Determine retcode based on first failure
+            if status_mode in ['all']:
+                # Use 'result' over 'retcode' if result is not None as
+                # 'retcode' reflects last run state, where 'result' is set
+                # explicitly
+                if status.result is not None:
+                    retcode = retcode or not status.result
 
-            elif status.retcode and status_mode in ['all']:
-                retcode = status.retcode
+                else:
+                    retcode = retcode or status.retcode
 
             if status.result and test_mode:
                 status.result = None


### PR DESCRIPTION
When multiple commands are called, properly report result of the last
one as the final result (when status_mode=last - the default), instead
of choosing last command that itself reported the 'status' field.

Furthermode, for the status_mode=all, really fail if there is any
failure. Previously if there was a success that had 'result' field, it
covered earlier failure (including one calculated for status_mode=last).

Fixes QubesOS/qubes-issues#10752